### PR TITLE
✨ Add richcat(), a python callable function to __init__.py

### DIFF
--- a/richcat/__init__.py
+++ b/richcat/__init__.py
@@ -5,3 +5,46 @@ __author__       = 'Yuta Yamamoto, Shotaro Kataoka'
 __author_email__ = 'automatuX78@gmail.com'
 __url__          = 'https://github.com/richcat-dev/richcat'
 
+
+from .richcat import infer_filetype, print_rich, is_error_input
+from .modules.consts._const import DIC_DEFAULT_VALUES
+
+
+def richcat(filepath, **args):
+    """
+    The richcat function called from Python script
+
+    Parameters
+    ----------
+    filepath : str
+        filepath
+    **args : args
+        filetype : str
+        width : int or float
+        color_system : str
+        style : str
+
+    Returns
+        None
+    -------
+
+    """
+
+    class Args():
+        def __init__(self):
+            self.filepath = filepath
+            self.filetype = args['filetype'] if 'filetype' in args.keys() else DIC_DEFAULT_VALUES['filetype']
+            self.width = args['width'] if 'width' in args.keys() else DIC_DEFAULT_VALUES['width']
+            self.color_system = args['color_system'] if 'color_system' in args.keys() else DIC_DEFAULT_VALUES['color_system']
+            self.style = args['style'] if 'style' in args.keys() else ''
+    args = Args()
+
+    """ Checking input error """
+    if is_error_input(args):
+        return
+
+    """ Infering FileType """
+    filepath, filetype = infer_filetype(args.filepath, args.filetype)
+
+    """ Print Rich """
+    print_rich(filepath, filetype, float(args.width), args.color_system, args.style)

--- a/richcat/modules/consts/_const.py
+++ b/richcat/modules/consts/_const.py
@@ -4,7 +4,7 @@ LST_COLOR_SYSTEM_CHOISES = ['standard', '256', 'truecolor', 'windows']
 DIC_DEFAULT_VALUES = {
     'color_system': '256',
     'filetype': 'auto',
-    'width': 1.0
+    'width': 1.0,
 }
 
 SYNTAX_MERGIN = 4 + 4

--- a/richcat/modules/consts/_const.py
+++ b/richcat/modules/consts/_const.py
@@ -4,7 +4,7 @@ LST_COLOR_SYSTEM_CHOISES = ['standard', '256', 'truecolor', 'windows']
 DIC_DEFAULT_VALUES = {
     'color_system': '256',
     'filetype': 'auto',
-    'width': 1.0,
+    'width': 1.0
 }
 
 SYNTAX_MERGIN = 4 + 4

--- a/richcat/modules/rich_makers/markdown_maker.py
+++ b/richcat/modules/rich_makers/markdown_maker.py
@@ -12,18 +12,23 @@ class MarkdownMaker(AbstractRichMaker):
     """ Markdown maker """
 
     def _decide_console_width(self, file_contents, target_width=DIC_DEFAULT_VALUES['width']):
-        # Get terminal width
-        terminal_width = self._get_terminal_width()
         # Decide target width
         if target_width < DIC_DEFAULT_VALUES['width']:
-            # Given width rate pattern
+            # -- Given width rate pattern
+            # Get terminal width
+            terminal_width = self._get_terminal_width()
+            # Calculate target width
             return int(float(terminal_width) * target_width)
         elif math.isclose(target_width, DIC_DEFAULT_VALUES['width']):
-            # Default pattern
+            # -- Default pattern
+            # Get terminal width
+            terminal_width = self._get_terminal_width()
+            # Get text width
             text_width = calc_max_line_length(file_contents) + MD_MERGIN
+            # Calculate terminal width
             return text_width if text_width < terminal_width else terminal_width
         else:
-            # Given target width directly pattern
+            # -- Given target width directly pattern
             return int(target_width)
 
     def _read_file(self, filepath):

--- a/richcat/modules/rich_makers/syntax_maker.py
+++ b/richcat/modules/rich_makers/syntax_maker.py
@@ -25,6 +25,7 @@ class SyntaxMaker(AbstractRichMaker):
             # Get text width
             text_width = calc_max_line_length(file_contents) + SYNTAX_MERGIN
             # Calculate terminal width
+            print(terminal_width)
             return text_width if text_width < terminal_width else terminal_width
         else:
             # -- Given target width directly pattern

--- a/richcat/modules/rich_makers/syntax_maker.py
+++ b/richcat/modules/rich_makers/syntax_maker.py
@@ -11,18 +11,23 @@ class SyntaxMaker(AbstractRichMaker):
     """ Syntax maker """
 
     def _decide_console_width(self, file_contents, target_width=DIC_DEFAULT_VALUES['width']):
-        # Get terminal width
-        terminal_width = self._get_terminal_width()
         # Decide target width
         if target_width < DIC_DEFAULT_VALUES['width']:
-            # Given width rate pattern
+            # -- Given width rate pattern
+            # Get terminal width
+            terminal_width = self._get_terminal_width()
+            # Calculate target width
             return int(float(terminal_width) * target_width)
         elif math.isclose(target_width, DIC_DEFAULT_VALUES['width']):
-            # Default pattern
+            # -- Default pattern
+            # Get terminal width
+            terminal_width = self._get_terminal_width()
+            # Get text width
             text_width = calc_max_line_length(file_contents) + SYNTAX_MERGIN
+            # Calculate terminal width
             return text_width if text_width < terminal_width else terminal_width
         else:
-            # Given target width directly pattern
+            # -- Given target width directly pattern
             return int(target_width)
 
     def _read_file(self, filepath):

--- a/richcat/modules/rich_makers/template.py
+++ b/richcat/modules/rich_makers/template.py
@@ -85,7 +85,7 @@ class AbstractRichMaker(ABC):
             return int(terminal_width)
         except ValueError:
             console = Console()
-            console.print(r'[bold red]\[richcat error][/bold red]: Cloud not get terminal width. Please give terminal width by using "-w" option.')
+            console.print(r'[bold red]\[richcat error][/bold red]: Cloud not get terminal width. Please give terminal width by using "width" option.')
             raise
 
     def _decide_console_width(self, file_contents, target_width=DIC_DEFAULT_VALUES['width']):

--- a/richcat/modules/rich_makers/template.py
+++ b/richcat/modules/rich_makers/template.py
@@ -85,7 +85,7 @@ class AbstractRichMaker(ABC):
             return int(terminal_width)
         except ValueError:
             console = Console()
-            console.print(r'[bold red]\[richcat error][/bold red]: Could not get terminal width. Please give terminal width by using "-w" option.')
+            console.print(r'[bold red]\[richcat eerror][/bold red]: Cloud not get terminal width. Please give terminal width by using "-w" option.')
             raise
 
     def _decide_console_width(self, file_contents, target_width=DIC_DEFAULT_VALUES['width']):
@@ -107,7 +107,7 @@ class AbstractRichMaker(ABC):
         # Get terminal width
         terminal_width = self._get_terminal_width()
         # Decide target width
-        if target_width <= 1.0:
+        if target_width <= DIC_DEFAULT_VALUES['width']:
             return int(float(terminal_width) * target_width)
         else:
             return int(target_width)

--- a/richcat/modules/rich_makers/template.py
+++ b/richcat/modules/rich_makers/template.py
@@ -80,8 +80,13 @@ class AbstractRichMaker(ABC):
         terminal_width : int
             terminal width
         """
-        _, terminal_width = os.popen('stty size', 'r').read().split()
-        return int(terminal_width)
+        try:
+            _, terminal_width = os.popen('stty size', 'r').read().split()
+            return int(terminal_width)
+        except ValueError:
+            console = Console()
+            console.print(r'[bold red]\[richcat error][/bold red]: Could not get terminal width. Please give terminal width by using "-w" option.')
+            raise
 
     def _decide_console_width(self, file_contents, target_width=DIC_DEFAULT_VALUES['width']):
         """

--- a/richcat/modules/rich_makers/template.py
+++ b/richcat/modules/rich_makers/template.py
@@ -85,7 +85,7 @@ class AbstractRichMaker(ABC):
             return int(terminal_width)
         except ValueError:
             console = Console()
-            console.print(r'[bold red]\[richcat eerror][/bold red]: Cloud not get terminal width. Please give terminal width by using "-w" option.')
+            console.print(r'[bold red]\[richcat error][/bold red]: Cloud not get terminal width. Please give terminal width by using "-w" option.')
             raise
 
     def _decide_console_width(self, file_contents, target_width=DIC_DEFAULT_VALUES['width']):

--- a/test/Untitled.ipynb
+++ b/test/Untitled.ipynb
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "80\n",
+      "\u001b[1;38;5;253;48;5;235m  \u001b[0m\u001b[38;5;241;48;5;235m1 \u001b[0m\u001b[38;5;149;48;5;235mecho\u001b[0m\u001b[38;5;231;48;5;235m \u001b[0m\u001b[38;5;222;48;5;235m\"hello world\"\u001b[0m\u001b[48;5;235m    \u001b[0m\n",
+      "\u001b[1;38;5;253;48;5;235m  \u001b[0m\u001b[38;5;241;48;5;235m2 \u001b[0m\u001b[38;5;149;48;5;235ma\u001b[0m\u001b[38;5;204;48;5;235m=\u001b[0m\u001b[38;5;149;48;5;235mbbb\u001b[0m\u001b[48;5;235m                 \u001b[0m\n",
+      "\u001b[1;38;5;253;48;5;235m  \u001b[0m\u001b[38;5;241;48;5;235m3 \u001b[0m\u001b[38;5;149;48;5;235mecho\u001b[0m\u001b[38;5;231;48;5;235m \u001b[0m\u001b[38;5;149;48;5;235m$a\u001b[0m\u001b[48;5;235m               \u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!richcat test.js"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from richcat import richcat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1;38;5;253;48;5;235m  \u001b[0m\u001b[38;5;241;48;5;235m1 \u001b[0m\u001b[38;5;231;48;5;235mecho\u001b[0m\u001b[38;5;231;48;5;235m \u001b[0m\u001b[38;5;222;48;5;235m\"\u001b[0m\u001b[38;5;222;48;5;235mhello world\u001b[0m\u001b[38;5;222;48;5;235m\"\u001b[0m\u001b[48;5;235m                                                                              \u001b[0m\n",
+      "\u001b[1;38;5;253;48;5;235m  \u001b[0m\u001b[38;5;241;48;5;235m2 \u001b[0m\u001b[38;5;231;48;5;235ma\u001b[0m\u001b[38;5;204;48;5;235m=\u001b[0m\u001b[38;5;231;48;5;235mbbb\u001b[0m\u001b[48;5;235m                                                                                           \u001b[0m\n",
+      "\u001b[1;38;5;253;48;5;235m  \u001b[0m\u001b[38;5;241;48;5;235m3 \u001b[0m\u001b[38;5;231;48;5;235mecho\u001b[0m\u001b[38;5;231;48;5;235m \u001b[0m\u001b[38;5;126;48;5;52m$\u001b[0m\u001b[38;5;231;48;5;235ma\u001b[0m\u001b[48;5;235m                                                                                         \u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": [
+       "<rich.jupyter.JupyterRenderable at 0x7fcfa62887f0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "richcat('test.py', width=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; font-weight: bold\">[richcat error]</span>: Cloud not get terminal width. Please give terminal width by using <span style=\"color: #008000\">\"-w\"</span> \n",
+       "option.\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "<rich.jupyter.JupyterRenderable at 0x7fcfa031f700>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "not enough values to unpack (expected 2, got 0)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-6-f4ad24f22824>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mrichcat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'test.py'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/develop/richcat/richcat/__init__.py\u001b[0m in \u001b[0;36mrichcat\u001b[0;34m(filepath, **args)\u001b[0m\n\u001b[1;32m     48\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     49\u001b[0m     \u001b[0;34m\"\"\" Print Rich \"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 50\u001b[0;31m     \u001b[0mprint_rich\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfiletype\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfloat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwidth\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolor_system\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstyle\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/develop/richcat/richcat/richcat.py\u001b[0m in \u001b[0;36mprint_rich\u001b[0;34m(filepath, filetype, target_width, color_system, style)\u001b[0m\n\u001b[1;32m    145\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    146\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 147\u001b[0;31m         \u001b[0mmaker\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mSyntaxMaker\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtarget_width\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcolor_system\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdic_style\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilepath\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfiletype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfiletype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    148\u001b[0m         \u001b[0mmaker\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdic_style\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'pager'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    149\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/develop/richcat/richcat/modules/rich_makers/template.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, target_width, color_system, dic_style, filepath, file_contents, filetype)\u001b[0m\n\u001b[1;32m     49\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     50\u001b[0m         \u001b[0;31m# Instance console\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 51\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconsole\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mConsole\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcolor_system\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcolor_system\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwidth\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_decide_console_width\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfile_contents\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtarget_width\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     52\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muse_pager\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/develop/richcat/richcat/modules/rich_makers/syntax_maker.py\u001b[0m in \u001b[0;36m_decide_console_width\u001b[0;34m(self, file_contents, target_width)\u001b[0m\n\u001b[1;32m     22\u001b[0m             \u001b[0;31m# -- Default pattern\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     23\u001b[0m             \u001b[0;31m# Get terminal width\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 24\u001b[0;31m             \u001b[0mterminal_width\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_terminal_width\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     25\u001b[0m             \u001b[0;31m# Get text width\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0mtext_width\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcalc_max_line_length\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfile_contents\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mSYNTAX_MERGIN\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/develop/richcat/richcat/modules/rich_makers/template.py\u001b[0m in \u001b[0;36m_get_terminal_width\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     82\u001b[0m         \"\"\"\n\u001b[1;32m     83\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 84\u001b[0;31m             \u001b[0m_\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mterminal_width\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'stty size'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'r'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msplit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     85\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mterminal_width\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     86\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: not enough values to unpack (expected 2, got 0)"
+     ]
+    }
+   ],
+   "source": [
+    "richcat('test.py')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
close #69 
```python
from richcat import richcat
richcat("test/sample.md", width=0.6)
```

とかでPythonスクリプト内から呼べるようにしました（需要は分からんが）
__init__.pyにmain()的な関数を作りました．
結構やっつけ実装なので問題あれば指摘ください

`class Args()`を作ったのは`is_error_input()`を使うためです