### PR TITLE
🐛 fix circular import error; __init__.py -> __information__.py

### DIFF
--- a/richcat/__information__.py
+++ b/richcat/__information__.py
@@ -1,0 +1,6 @@
+__copyright__    = 'Copyright (C) 2020 Yuta Yamamoto, Shotaro Kataoka'
+__version__      = '0.4.0'
+__license__      = 'MIT'
+__author__       = 'Yuta Yamamoto, Shotaro Kataoka'
+__author_email__ = 'automatuX78@gmail.com'
+__url__          = 'https://github.com/richcat-dev/richcat'

--- a/richcat/__init__.py
+++ b/richcat/__init__.py
@@ -1,11 +1,3 @@
-__copyright__    = 'Copyright (C) 2020 Yuta Yamamoto, Shotaro Kataoka'
-__version__      = '0.4.0'
-__license__      = 'MIT'
-__author__       = 'Yuta Yamamoto, Shotaro Kataoka'
-__author_email__ = 'automatuX78@gmail.com'
-__url__          = 'https://github.com/richcat-dev/richcat'
-
-
 from .richcat import infer_filetype, print_rich, is_error_input
 from .modules.consts._const import DIC_DEFAULT_VALUES
 

--- a/richcat/__init__.py
+++ b/richcat/__init__.py
@@ -1,6 +1,6 @@
 from .richcat import infer_filetype, print_rich, is_error_input
 from .modules.consts._const import DIC_DEFAULT_VALUES
-from .__information__ import __version__
+from .__information__ import __copyright__, __version__, __license__, __author__, __author_email__, __url__
 
 
 def richcat(filepath, **args):

--- a/richcat/__init__.py
+++ b/richcat/__init__.py
@@ -1,5 +1,6 @@
 from .richcat import infer_filetype, print_rich, is_error_input
 from .modules.consts._const import DIC_DEFAULT_VALUES
+from .__information__ import __version__
 
 
 def richcat(filepath, **args):
@@ -40,3 +41,4 @@ def richcat(filepath, **args):
 
     """ Print Rich """
     print_rich(filepath, filetype, float(args.width), args.color_system, args.style)
+

--- a/richcat/richcat.py
+++ b/richcat/richcat.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.console import RenderGroup
 
-from .__init__ import __version__
+from .__information__ import __version__
 from .modules.consts._const import LST_COLOR_SYSTEM_CHOISES, DIC_DEFAULT_VALUES
 from .modules.consts._ext2alias_dic_generator import DIC_LEXER_WC, DIC_LEXER_CONST
 from .modules.utils import extract_filename, extract_extension

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ root_dir = path.abspath(path.dirname(__file__))
 def _requirements():
     return [name.rstrip() for name in open(path.join(root_dir, 'requirements.txt')).readlines()]
 
-with open(path.join(root_dir, main_directory, '__init__.py')) as f:
+with open(path.join(root_dir, main_directory, '__information__.py')) as f:
     init_text = f.read()
     version = re.search(r'__version__\s*=\s*[\'\"](.+?)[\'\"]', init_text).group(1)
     license = re.search(r'__license__\s*=\s*[\'\"](.+?)[\'\"]', init_text).group(1)


### PR DESCRIPTION
close #72 

`__init__.py`の最初の部分を`__information__.py`に変更
合わせて`setup.py`, `richcat.py`を変更
