### PR TITLE
🐛 #29 を修正

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,5 @@
 # Colorize prompt
 export PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 
-# Show raw color on less
-export LESS="-R"
+# Set less command options
+export LESS="-F -g -i -M -R -S -w -X -z-4"

--- a/.bashrc
+++ b/.bashrc
@@ -1,2 +1,5 @@
-
+# Colorize prompt
 export PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+
+# Show raw color on less
+export LESS="-R"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR $HOME
 COPY .bashrc requirements.txt $HOME/
 
 # Installl commands
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
+    less
 
 # Install Python libraries
 RUN pip install --upgrade pip \


### PR DESCRIPTION
Fixes #29 

## やったこと
- Dockerコンテナ内でrichcatすると表示が崩れる問題を修正

## やったこと詳細
Dockerコンテナに `less` コマンドを追加して、 `-R` オプション付きで実行するようにした。

参考記事：
- [git config core.pager の謎 (というか) « のっち大好きの会 分室](http://blog.livedoor.jp/kosugip/archives/1586338.html)
- [lessのおすすめオプション - Qiita](https://qiita.com/takc923/items/598a68c4684114ffb102#ansi-color-escape-sequence%E3%82%92%E8%89%B2%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B-r)
- [UNIX/lessコマンドでlsやmanを色付き表示する - yanor.net/wiki](https://yanor.net/wiki/?UNIX/less%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E3%81%A7ls%E3%82%84man%E3%82%92%E8%89%B2%E4%BB%98%E3%81%8D%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B)

## 動作確認
