### PR TITLE
Topic/v0.5.0/issue 123 run workflow locally

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,3 @@
+-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest
+-P ubuntu-20.04=ghcr.io/catthehacker/ubuntu:act-20.04
+-P ubuntu-18.04=ghcr.io/catthehacker/ubuntu:act-18.04

--- a/.bashrc
+++ b/.bashrc
@@ -3,3 +3,6 @@ export PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\
 
 # Set less command options
 export LESS="-F -g -i -M -R -S -w -X -z-4"
+
+# Alias for act command
+alias act="~/bin/act"

--- a/.github/workflows/act-playground.yml
+++ b/.github/workflows/act-playground.yml
@@ -1,0 +1,12 @@
+name: act playground
+
+on:
+  pull_request:
+
+jobs:
+  act_prayground:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: test
+        run: echo "hello act"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     ports:
       - 8000:8000 # For Sphinx
     volumes:
-      - .:/home
+      - type: bind
+        source: "./"
+        target: "/home/"
+      - type: bind
+        source: "/var/run/docker.sock"
+        target: "/var/run/docker.sock"
     command: bash -c "pip install -e /home && make apidoc && make autobuild"
     tty: true


### PR DESCRIPTION
Fixes #123 

## やったこと
- 以下のツールを導入し、GtiHub Actionsのワークフローをローカルで動作できるようにした
  - [nektos/act: Run your GitHub Actions locally 🚀](https://github.com/nektos/act)

## 動作確認
Dockerコンテナ内にて、動作確認用ワークフロー `act-playground.yml` を利用して動作確認ができる。

```
root@aa6bed78a054:~# act -j act_test pull_request
[act test/act_test] 🚀  Start image=ghcr.io/catthehacker/ubuntu:act-latest
[act test/act_test]   🐳  docker pull image=ghcr.io/catthehacker/ubuntu:act-latest platform= username= forcePull=false
[act test/act_test]   🐳  docker create image=ghcr.io/catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[act test/act_test]   🐳  docker run image=ghcr.io/catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[act test/act_test]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[act test/act_test] ⭐  Run test
[act test/act_test]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/workflow/0] user= workdir=
| hello
[act test/act_test]   ✅  Success - test
```