### PR TITLE
🐛 拡張子判別を辞書経由で行うよう変更

### DIFF
--- a/richcat/richcat.py
+++ b/richcat/richcat.py
@@ -132,11 +132,11 @@ def print_rich(filetype, target_width, color_system, style, filepath=None, file_
             out, err = subprocess.Popen(f'jupyter nbconvert --stdin --stdout --to markdown --log-level WARN'.split(' '), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate(out)
             file_contents = out.decode('utf-8')
             filepath = None
-            filetype = 'md'
+            filetype = DIC_LEXER_WC['md']
         else:
-            filetype = 'json'
+            filetype = DIC_LEXER_WC['json']
 
-    if filetype == 'md':
+    if filetype == DIC_LEXER_WC['md']:
         maker = MarkdownMaker(target_width, color_system, dic_style, filepath=filepath, file_contents=file_contents)
         maker.print(dic_style['pager'])
 


### PR DESCRIPTION
Fixes #132 

## やったこと
- ファイル形式ごとに分岐する際のMarkdownファイルかどうか等を識別するための拡張子を、拡張子辞書中の値を使用するように変更した

## 動作確認
![image](https://user-images.githubusercontent.com/55144709/155152306-d3a490fc-ff27-4648-915f-8219545a5fae.png)
